### PR TITLE
Made audioplayer dart2 compatible.

### DIFF
--- a/lib/audioplayer.dart
+++ b/lib/audioplayer.dart
@@ -25,13 +25,22 @@ class AudioPlayer {
   }
 
   Future<int> play(String url, {bool isLocal: false, double volume: 1.0}) =>
-      _channel.invokeMethod('play', {"playerId": playerId, "url": url, "isLocal": isLocal, 'volume': volume});
+      _channel.invokeMethod('play', {
+        "playerId": playerId,
+        "url": url,
+        "isLocal": isLocal,
+        'volume': volume
+      }).then((result) => (result as int));
 
-  Future<int> pause() => _channel.invokeMethod('pause', {"playerId": playerId});
+  Future<int> pause() => _channel.invokeMethod(
+      'pause', {"playerId": playerId}).then((result) => (result as int));
 
-  Future<int> stop() => _channel.invokeMethod('stop', {"playerId": playerId});
+  Future<int> stop() => _channel.invokeMethod(
+      'stop', {"playerId": playerId}).then((result) => (result as int));
 
-  Future<int> seek(double seconds) => _channel.invokeMethod('seek', {"playerId": playerId, "position": seconds});
+  Future<int> seek(double seconds) => _channel.invokeMethod(
+      'seek', {"playerId": playerId, "position": seconds}).then(
+        (result) => (result as int));
 
   void setDurationHandler(TimeChangeHandler handler) {
     durationHandler = handler;


### PR DESCRIPTION
If you run the existing audio player with Dart 2 type checks, it fails because invokeMethod returns a Future<dynamic> rather than a Future<int>. This change explicitly casts the return type as an int so that the signature can remain the same.