### PR TITLE
Avoid restarting a looping player if is stopped

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -305,6 +305,10 @@ FlutterMethodChannel *_channel;
   NSLog(@"ios -> onSoundComplete...");
   NSMutableDictionary * playerInfo = players[playerId];
 
+  if (![playerInfo[@"isPlaying"] boolValue]) {
+    return;
+  }
+
   [ self pause:playerId ];
   [ self seek:playerId time:CMTimeMakeWithSeconds(0,1) ];
 


### PR DESCRIPTION
Corrected a bug that was causing a player to loop forever if it was stopped by a dart channel command some moments before its end.