### PR TITLE
Fix iOS speaker and background mode not working issue

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -218,7 +218,14 @@ FlutterMethodChannel *_channel;
          url: (NSString*) url
      isLocal: (int) isLocal
       volume: (float) volume
-{    
+{
+  NSError *error = nil;
+  BOOL success = [[AVAudioSession sharedInstance]
+                  setCategory:AVAudioSessionCategoryPlayback
+                  error:&error];
+  if (!success) {
+    NSLog(@"Error setting speaker: %@", error);
+  }
   [ self setUrl:url 
          isLocal:isLocal 
          playerId:playerId 


### PR DESCRIPTION
This pull request fixed following 2 issues
1. There is no voice when it's speaker mode(no headphone plugged in) on real iOS device, see #33 for details.
2. It's not working for iOS background mode even background modes has been enabled in Capacities when building the app. see #35 for details.