### PR TITLE
allow for nested assets in cache

### DIFF
--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -52,6 +52,7 @@ class AudioCache {
 
   Future<File> fetchToMemory(String fileName) async {
     final file = new File('${(await getTemporaryDirectory()).path}/$fileName');
+    await file.create(recursive: true);
     return await file
         .writeAsBytes((await _fetchAsset(fileName)).buffer.asUint8List());
   }


### PR DESCRIPTION
pubspec.yaml
```yaml
  assets:
    - assets/
    - assets/漢字/
    - assets/audio/
    - assets/audio/音/
    - assets/audio/音声/
```
main.dart
```dart
AudioCache player = new AudioCache(prefix: 'audio/');

void playVoice(fileName) {
  player.play(p.join('音声', fileName));
}

```

audio_cache.dart
```dart
    final file = new File('${(await getTemporaryDirectory()).path}/$fileName');
    /* File's path is "/data/.../cache/audio/音声/a.mp3", but 
the directories from the cache directory leading up to
 the file haven't been created yet, so unless we call 
`create` recursively, attempting to write data to the
 file will fail */
    await file.create(recursive: true);
    return await file
        .writeAsBytes((await _fetchAsset(fileName)).buffer.asUint8List());
```