### PR TITLE
Delay seek operations on Android until player is ready.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages
 .project
 .settings
 .vscode
+testing

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -29,6 +29,8 @@ public class WrappedMediaPlayer implements MediaPlayer.OnPreparedListener, Media
     private boolean prepared = false;
     private boolean playing = false;
 
+    private double shouldSeekTo;
+
     private MediaPlayer player;
     private AudioplayersPlugin ref;
 
@@ -144,8 +146,13 @@ public class WrappedMediaPlayer implements MediaPlayer.OnPreparedListener, Media
         }
     }
 
+    // seek operations cannot be called until after
+    // the player is ready.
     public void seek(double position) {
-        this.player.seekTo((int) (position * 1000));
+        if (this.prepared)
+            this.player.seekTo((int) (position * 1000));
+        else
+            this.shouldSeekTo = position;
     }
 
     public int getDuration() {
@@ -179,6 +186,10 @@ public class WrappedMediaPlayer implements MediaPlayer.OnPreparedListener, Media
         if (this.playing) {
             this.player.start();
             ref.handleIsPlaying(this);
+        }
+        if (this.shouldSeekTo != null) {
+            this.player.seekTo((int) (this.shouldSeekTo * 1000));
+            this.shouldSeekTo = null;
         }
     }
 

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -29,7 +29,7 @@ public class WrappedMediaPlayer implements MediaPlayer.OnPreparedListener, Media
     private boolean prepared = false;
     private boolean playing = false;
 
-    private double shouldSeekTo;
+    private double shouldSeekTo = -1;
 
     private MediaPlayer player;
     private AudioplayersPlugin ref;
@@ -187,9 +187,9 @@ public class WrappedMediaPlayer implements MediaPlayer.OnPreparedListener, Media
             this.player.start();
             ref.handleIsPlaying(this);
         }
-        if (this.shouldSeekTo != null) {
+        if (this.shouldSeekTo >= 0) {
             this.player.seekTo((int) (this.shouldSeekTo * 1000));
-            this.shouldSeekTo = null;
+            this.shouldSeekTo = -1;
         }
     }
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.jeffmikels.audioplayersexample;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.luan.audioplayersExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.jeffmikels.audioplayersexample;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.luan.audioplayersExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = xyz.luan.audioplayersExample;
+				PRODUCT_BUNDLE_IDENTIFIER = org.jeffmikels.audioplayersexample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = xyz.luan.audioplayersExample;
+				PRODUCT_BUNDLE_IDENTIFIER = org.jeffmikels.audioplayersexample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -252,13 +252,14 @@ FlutterMethodChannel *_channel_audioplayer;
   }
 }
 
+// No need to spam the logs with every time interval update
 -(void) onTimeInterval: (NSString *) playerId
                   time: (CMTime) time {
-  NSLog(@"ios -> onTimeInterval...");
-  int mseconds =  CMTimeGetSeconds(time)*1000;
-    NSLog(@"asdff %@ - %d", playerId, mseconds);
-  [_channel_audioplayer invokeMethod:@"audio.onCurrentPosition" arguments:@{@"playerId": playerId, @"value": @(mseconds)}];
-    NSLog(@"asdff end");
+    // NSLog(@"ios -> onTimeInterval...");
+    int mseconds =  CMTimeGetSeconds(time)*1000;
+    // NSLog(@"asdff %@ - %d", playerId, mseconds);
+    [_channel_audioplayer invokeMethod:@"audio.onCurrentPosition" arguments:@{@"playerId": playerId, @"value": @(mseconds)}];
+    //    NSLog(@"asdff end");
 }
 
 -(void) pause: (NSString *) playerId {


### PR DESCRIPTION
The "play" and "setUrl" methods return before the player is actually ready.
If "seek" is called too soon, the Android layer will throw an error.
To fix this, we store seek operations on the Android side until the player is ready and then execute the most recent one once it is.